### PR TITLE
Fix gemspec source_code_uri

### DIFF
--- a/solidus_redirector.gemspec
+++ b/solidus_redirector.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   if s.respond_to?(:metadata)
     s.metadata["homepage_uri"] = s.homepage if s.homepage
-    s.metadata["source_code_uri"] = s.homepage if s.homepage
+    s.metadata["source_code_uri"] = 'https://github.com/solidusio-contrib/solidus_redirector'
   end
 
   s.add_dependency 'redirector'


### PR DESCRIPTION
It is used to install the [changelog generator](https://github.com/solidusio/solidus_dev_support/blob/master/lib/solidus_dev_support/rake_tasks.rb#L76) and the [Ci fails](https://app.circleci.com/pipelines/github/solidusio-contrib/solidus_redirector/51/workflows/88a1f751-4b67-4f52-844a-d8e50d3577f5/jobs/154) without this info.
